### PR TITLE
chore: support get billing document breakdown endpoint

### DIFF
--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@remoteoss/ai-agent-toolkit",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Toolkit for integrating the Remote API into agentic workflows",
   "author": "Remote.com <engineering@remote.com> (https://remote.com/)",
   "license": "MIT",

--- a/typescript/src/client/api.client.ts
+++ b/typescript/src/client/api.client.ts
@@ -52,6 +52,8 @@ import type {
   ListBillingDocumentsResponse,
   ShowBillingDocumentParams,
   ShowBillingDocumentResponse,
+  GetBillingDocumentBreakdownParams,
+  GetBillingDocumentBreakdownResponse,
 } from './billing.types';
 
 export interface ApiClient {
@@ -88,6 +90,10 @@ export interface ApiClient {
   ): Promise<SentBackTimesheetResponse>;
   listBillingDocuments(params: ListBillingDocumentsParams): Promise<ListBillingDocumentsResponse>;
   showBillingDocument(params: ShowBillingDocumentParams): Promise<ShowBillingDocumentResponse>;
+  getBillingDocumentBreakdown(
+    billing_document_id: string,
+    params: GetBillingDocumentBreakdownParams,
+  ): Promise<GetBillingDocumentBreakdownResponse>;
 }
 
 export class RemoteApiClient implements ApiClient {
@@ -345,6 +351,15 @@ export class RemoteApiClient implements ApiClient {
     const { billing_document_id } = params;
     return this.request<ShowBillingDocumentResponse>(
       `/billing-documents/${billing_document_id}`,
+      'GET',
+    );
+  }
+  async getBillingDocumentBreakdown(
+    billing_document_id: string,
+    params: GetBillingDocumentBreakdownParams,
+  ): Promise<GetBillingDocumentBreakdownResponse> {
+    return this.request<GetBillingDocumentBreakdownResponse>(
+      `/billing-documents/${billing_document_id}/breakdown`,
       'GET',
     );
   }

--- a/typescript/src/client/billing.types.ts
+++ b/typescript/src/client/billing.types.ts
@@ -51,3 +51,26 @@ export interface BillingDocument {
 export interface ShowBillingDocumentResponse {
   billing_document: BillingDocument;
 }
+
+export interface BillingDocumentBreakdown {
+  country_code: string;
+  description: string;
+  employment_id: string;
+  fx_rate: string;
+  invoice_amount: number;
+  invoice_currency: string | null; // Currency code in ISO 4217 format.
+  invoice_number: string;
+  invoice_period: string;
+  source_amount: number;
+  source_currency: string | null;
+  type: string;
+  variance_from_invoice: number | null;
+}
+
+export interface GetBillingDocumentBreakdownParams {
+  type: string;
+}
+
+export interface GetBillingDocumentBreakdownResponse {
+  billing_document_breakdown: BillingDocumentBreakdown[];
+}

--- a/typescript/src/tools/billing/getBillingDocumentBreakdown.ts
+++ b/typescript/src/tools/billing/getBillingDocumentBreakdown.ts
@@ -1,0 +1,63 @@
+import { z } from 'zod';
+import type { Context } from '../../shared/configuration';
+import type { Tool, ToolFactory } from '../../shared/tools';
+import type {
+  GetBillingDocumentBreakdownParams,
+  GetBillingDocumentBreakdownResponse,
+} from '../../client/billing.types';
+import type { ApiClient } from '../../client/api.client';
+
+export const getBillingDocumentBreakdownPrompt: string = `
+This tool fetches the breakdown of a billing document by its ID from the Remote API.
+
+It takes the following parameters:
+- billing_document_id: The ID of the billing document to get the breakdown for.
+- type: Filters the results by the type of the billing breakdown item.
+
+It returns the following data:
+- billing_document_breakdown: The detailed breakdown of the billing document.
+`;
+
+export const getBillingDocumentBreakdownParameters = (
+  _context?: Context,
+): z.ZodObject<{
+  billing_document_id: z.ZodString;
+}> =>
+  z.object({
+    billing_document_id: z
+      .string()
+      .min(1, 'Billing document ID cannot be empty')
+      .describe(`The billing document's ID`),
+    type: z.string().describe('Filters the results by the type of the billing breakdown item.'),
+  });
+
+export const getBillingDocumentBreakdown = async (
+  apiClient: ApiClient,
+  _context: Context,
+  params: { [x: string]: any },
+): Promise<GetBillingDocumentBreakdownResponse | string> => {
+  try {
+    const { billing_document_id, type } = params;
+    const billingDocumentBreakdownData = await apiClient.getBillingDocumentBreakdown(
+      billing_document_id,
+      { type } as GetBillingDocumentBreakdownParams,
+    );
+    return billingDocumentBreakdownData;
+  } catch (error) {
+    console.error('Failed to get billing document breakdown:', error);
+    if (error instanceof Error) {
+      return `Failed to get billing document breakdown: ${error.message}`;
+    }
+    return 'Failed to get billing document breakdown due to an unexpected error.';
+  }
+};
+
+const toolFactory: ToolFactory = (context: Context): Tool => ({
+  method: 'get_billing_document_breakdown',
+  name: 'Get Billing Document Breakdown',
+  description: getBillingDocumentBreakdownPrompt,
+  parameters: getBillingDocumentBreakdownParameters(context),
+  execute: getBillingDocumentBreakdown,
+});
+
+export default toolFactory;

--- a/typescript/src/tools/index.ts
+++ b/typescript/src/tools/index.ts
@@ -28,6 +28,7 @@ import sendBackTimesheetToolFactory from './sendBackTimesheet';
 import listPayslipsToolFactory from './listPayslips';
 import listBillingDocumentsToolFactory from './billing/listBillingDocuments';
 import showBillingDocumentToolFactory from './billing/showBillingDocument';
+import getBillingDocumentBreakdownToolFactory from './billing/getBillingDocumentBreakdown';
 
 export const toolFactories: ToolFactory[] = [
   listTimeOffToolFactory,
@@ -58,6 +59,7 @@ export const toolFactories: ToolFactory[] = [
   listPayslipsToolFactory,
   listBillingDocumentsToolFactory,
   showBillingDocumentToolFactory,
+  getBillingDocumentBreakdownToolFactory,
 ];
 
 const getAllTools: ToolListFactory = (context: Context) => {


### PR DESCRIPTION
- Bumped version to 0.1.4 in package.json.
- Introduced new types and API client methods for getting billing documents breakdown.
- Added a new tool for getting billing documents breakdown with parameter validation.
- Updated index files to export new billing types and tools.