### PR TITLE
fix: remove API key from context object and update README with contractor invoice tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,10 +103,12 @@ The toolkit provides a set of tools to interact with the Remote API. The followi
 | Create Time Off             | Create a new time off request (pre-approved)          | `create_time_off`             |
 | Decline Cancel Request      | Decline a request to cancel time off                  | `decline_cancel_request`      |
 | Decline Time Off            | Decline a pending time off request                    | `decline_time_off`            |
+| Get Contractor Invoice      | Retrieve details of a specific contractor invoice     | `get_contractor_invoice`      |
 | Get Expense                 | Retrieve details of a specific expense                | `get_expense`                 |
 | Get Time Off                | Retrieve details of a specific time off request       | `get_time_off`                |
 | Get Timesheet               | Retrieve details of a specific timesheet              | `get_timesheet`               |
 | List Company Managers       | List all company managers                             | `list_company_managers`       |
+| List Contractor Invoices    | List contractor invoices with filtering options       | `list_contractor_invoices`    |
 | List Employments            | List employment records with filtering options        | `list_employments`            |
 | List Expenses               | List expense records with filtering and pagination    | `list_expenses`               |
 | List Incentives             | List incentive records                                | `list_incentives`             |

--- a/typescript/src/langchain/toolkit.ts
+++ b/typescript/src/langchain/toolkit.ts
@@ -21,7 +21,7 @@ export class RemoteApiAgentToolkit extends BaseToolkit {
       throw new Error('API key is required for RemoteApiAgentToolkit');
     }
     this._apiClient = new RemoteApiClient(apiKey, apiBaseUrl);
-    this._context = { apiKey, allowedTools };
+    this._context = { allowedTools };
 
     this.tools = getAllTools(this._context).map(
       (toolDefinition) =>

--- a/typescript/src/mcp/mcp_server.ts
+++ b/typescript/src/mcp/mcp_server.ts
@@ -28,7 +28,7 @@ export class RemoteApiMcpServer extends McpServer {
       throw new Error('API key is required for RemoteApiMcpServer');
     }
     this.apiClient = new RemoteApiClient(apiKey, apiBaseUrl);
-    this.internalContext = { apiKey, allowedTools };
+    this.internalContext = { allowedTools };
 
     this.registerTools();
   }


### PR DESCRIPTION
## Summary

  - Remove `apiKey` from the `Context` object in `toolkit.ts` and `mcp_server.ts` — it was unused dead code since `RemoteApiClient` already holds it privately. Eliminates a potential credential leakage path if the
  context object were ever serialized or logged.
  - Update root `README.md` to document the two contractor invoice tools added in #9 that were missing from the supported tools table.

  ## Changes

  ### Security fix
  Removed `apiKey` from the `Context` object in both LangChain and MCP server constructors:

  ```ts
  // Before
  this._context = { apiKey, allowedTools };

  // After
  this._context = { allowedTools };

  No tool ever read apiKey from context — the API client already holds it privately — so this is a safe removal with no functional impact.

  README

  Added missing tools to the supported API methods table:
  - Get Contractor Invoice (get_contractor_invoice)
  - List Contractor Invoices (list_contractor_invoices)

  Testing

  - npm run build — clean ✅
  - npm test — 11/11 passing ✅
  - Manually tested in Claude Code — toolkit works as expected ✅