### PR TITLE
chore: add automated MCPB release workflow

### DIFF
--- a/.github/workflows/release-mcpb.yml
+++ b/.github/workflows/release-mcpb.yml
@@ -1,0 +1,49 @@
+name: Release MCPB
+
+on:
+  push:
+    tags:
+      - 'mcp-v*'
+
+jobs:
+  build-and-release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install dependencies (including dev for build)
+        working-directory: mcp
+        run: npm ci
+
+      - name: Build
+        working-directory: mcp
+        run: npm run build
+
+      - name: Remove dev dependencies before packing
+        working-directory: mcp
+        run: npm prune --omit=dev
+
+      - name: Get version
+        id: version
+        working-directory: mcp
+        run: echo "version=$(node -p 'require("./manifest.json").version')" >> $GITHUB_OUTPUT
+
+      - name: Pack MCPB
+        working-directory: mcp
+        run: npx --yes @anthropic-ai/mcpb pack . remote-mcp-${{ steps.version.outputs.version }}.mcpb
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create ${{ github.ref_name }} \
+            mcp/remote-mcp-${{ steps.version.outputs.version }}.mcpb \
+            --title "${{ github.ref_name }}" \
+            --generate-notes

--- a/mcp/.mcpbignore
+++ b/mcp/.mcpbignore
@@ -1,0 +1,7 @@
+src/
+eslint.config.mjs
+jest.config.js
+coverage/
+*.test.js
+.env
+.env.*

--- a/mcp/package-lock.json
+++ b/mcp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@remoteoss/mcp",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@remoteoss/mcp",
-      "version": "0.1.5",
+      "version": "0.1.6",
       "license": "MIT",
       "dependencies": {
         "@remoteoss/ai-agent-toolkit": "0.1.6",
@@ -2754,9 +2754,9 @@
       "peer": true
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.21",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.21.tgz",
-      "integrity": "sha512-Q+rUQ7Uz8AHM7DEaNdwvfFCTq7a43lNTzuS94eiWqwyxfV/wJv+oUivef51T91mmRY4d4A1u9rcSvkeufCVXlA==",
+      "version": "2.10.23",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.23.tgz",
+      "integrity": "sha512-xwVXGqevyKPsiuQdLj+dZMVjidjJV508TBqexND5HrF89cGdCYCJFB3qhcxRHSeMctdCfbR1jrxBajhDy7o29g==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -2947,9 +2947,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001790",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001790.tgz",
-      "integrity": "sha512-bOoxfJPyYo+ds6W0YfptaCWbFnJYjh2Y1Eow5lRv+vI2u8ganPZqNm1JwNh0t2ELQCqIWg4B3dWEusgAmsoyOw==",
+      "version": "1.0.30001791",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001791.tgz",
+      "integrity": "sha512-yk0l/YSrOnFZk3UROpDLQD9+kC1l4meK/wed583AXrzoarMGJcbRi2Q4RaUYbKxYAsZ8sWmaSa/DsLmdBeI1vQ==",
       "dev": true,
       "funding": [
         {

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@remoteoss/mcp",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "private": false,
   "description": "A CLI to run the Remote AI Agent Toolkit MCP server.",
   "license": "MIT",


### PR DESCRIPTION
## Summary

  - Adds a GitHub Actions workflow that builds and publishes the `.mcpb`
    Claude Desktop extension on `mcp-v*` tag pushes
  - Creates `.mcpbignore` to exclude dev-only files (`src/`, `eslint.config.mjs`,
    `jest.config.js`, `coverage/`, `*.test.js`, `.env`) from the bundle
  - Bumps `@remoteoss/mcp` version to `0.1.6` to match `manifest.json`

  ## How it works

  Push a tag to trigger the release:
  git tag mcp-v0.1.6
  git push origin mcp-v0.1.6

  The workflow will:
  1. Install dependencies and compile TypeScript
  2. Prune dev dependencies before packing
  3. Create a `remote-mcp-<version>.mcpb` bundle
  4. Attach it to a GitHub Release with auto-generated notes